### PR TITLE
Patch Fix BlenderTools dev server option `server.fs.deny` can be bypassed when hosted on case-insensitive filesystem

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "sort-package-json": "^2.6.0",
         "ts-unused-exports": "^10.0.1",
         "typescript": "^5.0.2",
-        "vite": "^4.4.5"
+        "vite": "^4.5.2"
       },
       "peerDependencies": {
         "react": "^18.2.0",
@@ -5199,9 +5199,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.0.tgz",
-      "integrity": "sha512-ulr8rNLA6rkyFAlVWw2q5YJ91v098AFQ2R0PRFwPzREXOUJQPtFUG0t+/ZikhaOCDqFoDhN6/v8Sq0o4araFAw==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.2.tgz",
+      "integrity": "sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",
@@ -8786,9 +8786,9 @@
       }
     },
     "vite": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.0.tgz",
-      "integrity": "sha512-ulr8rNLA6rkyFAlVWw2q5YJ91v098AFQ2R0PRFwPzREXOUJQPtFUG0t+/ZikhaOCDqFoDhN6/v8Sq0o4araFAw==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.2.tgz",
+      "integrity": "sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==",
       "dev": true,
       "requires": {
         "esbuild": "^0.18.10",


### PR DESCRIPTION

## Update 👾 Describe The Sumarry:
Affected of this project `frontapp/front-chat-sdk` are vulnerable to Access Control Bypass via the server.fs.deny option. An attacker can gain access to sensitive files by requesting raw filesystem paths using case-augmented versions of filenames. This is only exploitable if the server is hosted on a case-insensitive filesystem, including those used by Windows. This bypass is similar to CVE-2023-34092 with surface area reduced to hosts having case-insensitive filesystems.

**Details**
Since `picomatch` defaults to case-sensitive glob matching, but the file server doesn't discriminate; a blacklist bypass is possible. See `picomatch` usage, where `nocase` is defaulted to `false`:
```js
 _setInternalServer(_server: ViteDevServer) {
      // Rebind internal the server variable so functions reference the user
      // server instance after a restart
      server = _server
    },
    _restartPromise: null,
    _importGlobMap: new Map(),
    _forceOptimizeOnRestart: false,
    _pendingRequests: new Map(),
    _fsDenyGlob: picomatch(config.server.fs.deny, { matchBase: true }),
```

**PoCs By IAP ZeroDay:**
`npm run dev -- --host 0.0.0.0`
Created dummy secret files, e.g. `custom.secret` and `production.pem`

```rb
export default { server: { fs: { deny: ['.env', '.env.*', '*.{crt,pem}', 'custom.secret'] } } }
```

## 🥷 According CVeScores:
Users with exposed dev servers on environments with case-insensitive filesystems Files protected by `server.fs.deny` are both discoverable, and accessible

CVE-2024-23331
CWE-178
CWE-200
CWE-284
`CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N`