### PR TITLE
Remove private flag to prevent packaging issues in Yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "front-chat-sdk",
   "version": "0.0.0",
-  "private": true,
   "type": "module",
   "scripts": {
     "build": "tsc && vite build",


### PR DESCRIPTION
This PR drops `private: true` from the `package.json` file, since this appears to cause a known issue in Yarn 4 (a widely-used alternative to NPM) where new checksums are generated periodically, rather than being reproducible.