### PR TITLE
Fix embed example for chromium browsers

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -4,7 +4,7 @@ module.exports = {
   root: true,
   env: {browser: true, es2020: true},
   extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'plugin:react-hooks/recommended'],
-  ignorePatterns: ['.eslintrc.cjs', 'examples', 'dist', 'node_modules'],
+  ignorePatterns: ['.eslintrc.cjs', 'examples', 'dist'],
   parser: '@typescript-eslint/parser',
   parserOptions: {
     project: path.join(__dirname, 'tsconfig.json')

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -4,7 +4,7 @@ module.exports = {
   root: true,
   env: {browser: true, es2020: true},
   extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'plugin:react-hooks/recommended'],
-  ignorePatterns: ['.eslintrc.cjs', 'examples'],
+  ignorePatterns: ['.eslintrc.cjs', 'examples', 'dist', 'node_modules'],
   parser: '@typescript-eslint/parser',
   parserOptions: {
     project: path.join(__dirname, 'tsconfig.json')

--- a/examples/react-embed-front-chat/index.tsx
+++ b/examples/react-embed-front-chat/index.tsx
@@ -1,4 +1,4 @@
-import {type SyntheticEvent} from 'react';
+import {useEffect, useRef} from 'react';
 
 /*
  * Constants.
@@ -20,9 +20,14 @@ const iframeStyle = {
  */
 
 function App() {
-  const onLoadIframe = async (event: SyntheticEvent<HTMLIFrameElement>) => {
-    const iframe = event.target as HTMLIFrameElement;
+  const iframeRef = useRef<HTMLIFrameElement>(null);
 
+  const onLoadIframe = () => {
+    if (!iframeRef.current) {
+      return;
+    }
+
+    const iframe = iframeRef.current;
     const scriptTag = document.createElement('script');
     scriptTag.setAttribute('type', 'text/javascript');
     scriptTag.setAttribute('src', scriptSrc);
@@ -40,11 +45,17 @@ function App() {
     iframe.contentDocument?.body.appendChild(scriptTag);
   };
 
+  useEffect(() => {
+    if (iframeRef.current) {
+      onLoadIframe();
+    }
+  }, []);
+
   return (
     <div>
       <h1>Embedded Front Chat</h1>
 
-      <iframe style={iframeStyle} onLoad={onLoadIframe} />
+      <iframe style={iframeStyle} ref={iframeRef} onLoad={onLoadIframe} />
 
       <h1>Below the Widget</h1>
       <p>You can have content above and below the embedded widget.</p>

--- a/examples/react-embed-front-chat/index.tsx
+++ b/examples/react-embed-front-chat/index.tsx
@@ -28,6 +28,7 @@ function App() {
     }
 
     const iframe = iframeRef.current;
+
     const scriptTag = document.createElement('script');
     scriptTag.setAttribute('type', 'text/javascript');
     scriptTag.setAttribute('src', scriptSrc);


### PR DESCRIPTION
This change addresses https://github.com/frontapp/front-chat-sdk/issues/17 . The `script.onload` function was not consistently being called across browsers. 

Also includes a drive-by fix for eslint regarding ignoring `dist` and `node_modules`.