### PR TITLE
Set registry-url for setup-node

### DIFF
--- a/.github/actions/cache-and-install-npm/action.yaml
+++ b/.github/actions/cache-and-install-npm/action.yaml
@@ -9,6 +9,7 @@ runs:
       uses: actions/setup-node@v3
       with:
         node-version: 16
+        registry-url: https://registry.npmjs.org
 
     - name: Install dependencies
       shell: bash


### PR DESCRIPTION
Fixes an issue with github actions where npm publish fails without setting `registry-url`.