### PR TITLE
feat: adding types for frontChat

### DIFF
--- a/examples/boot/index.ts
+++ b/examples/boot/index.ts
@@ -1,4 +1,5 @@
 import {boot} from '../../lib/helpers/boot';
+import {FrontChatCmdType} from '../../lib/types/front-chat-types';
 
 /*
  * Constants.
@@ -17,9 +18,9 @@ boot(document.body)
     // option to the 'init' command. The below callback is just an example of waiting for the chat widget to
     // be initialized, before performing another action.
     const onInitCompleted = () => {
-      frontChat('show');
+      frontChat(FrontChatCmdType.Show);
     };
 
-    frontChat('init', {chatId, onInitCompleted});
+    frontChat(FrontChatCmdType.Init, {chatId, onInitCompleted});
   })
   .catch(console.error);

--- a/examples/react-embed-front-chat/index.tsx
+++ b/examples/react-embed-front-chat/index.tsx
@@ -1,5 +1,7 @@
 import {useEffect, useRef} from 'react';
 
+import {FrontChatCmdType} from '../../lib/types/front-chat-types';
+
 /*
  * Constants.
  */
@@ -33,7 +35,7 @@ export function App() {
     scriptTag.setAttribute('type', 'text/javascript');
     scriptTag.setAttribute('src', scriptSrc);
     scriptTag.onload = () => {
-      iframe.contentWindow?.FrontChat?.('init', {
+      iframe.contentWindow?.FrontChat?.(FrontChatCmdType.Init, {
         chatId,
         useDefaultLauncher: false,
         shouldShowWindowOnLaunch: true,

--- a/examples/react-use-front-chat-boot/index.tsx
+++ b/examples/react-use-front-chat-boot/index.tsx
@@ -39,5 +39,5 @@ export function App() {
     setIsWindowVisible;
   }, [frontChat, isInitialized, isWindowVisible]);
 
-  return <div>isInitialized: {isInitialized}</div>;
+  return <div>isInitialized: {isInitialized ? 'True' : 'False'}</div>;
 }

--- a/examples/react-use-front-chat-boot/index.tsx
+++ b/examples/react-use-front-chat-boot/index.tsx
@@ -1,6 +1,7 @@
 import {useEffect, useState} from 'react';
 
 import {useFrontChatBoot} from '../../lib/hooks/use-front-chat-boot';
+import {FrontChatCmdType} from '../../lib/types/front-chat-types';
 
 /*
  * Constants.
@@ -34,9 +35,9 @@ export function App() {
       return;
     }
 
-    frontChat('show');
+    frontChat(FrontChatCmdType.Show);
     setIsWindowVisible;
   }, [frontChat, isInitialized, isWindowVisible]);
 
-  return <div>isInitialized: {isInitialized ? 'True' : 'False'}</div>;
+  return <div>isInitialized: {isInitialized}</div>;
 }

--- a/examples/react-verified-user/index.tsx
+++ b/examples/react-verified-user/index.tsx
@@ -2,6 +2,7 @@ import {createHmac} from 'crypto';
 import {useEffect, useState} from 'react';
 
 import {useFrontChatBoot} from '../../lib/hooks/use-front-chat-boot';
+import {FrontChatCmdType} from '../../lib/types/front-chat-types';
 
 /*
  * Constants.
@@ -52,7 +53,7 @@ export function App() {
       return;
     }
 
-    frontChat('show');
+    frontChat(FrontChatCmdType.Show);
     setIsWindowVisible;
   }, [frontChat, isInitialized, isWindowVisible]);
 

--- a/lib/helpers/initialize/index.ts
+++ b/lib/helpers/initialize/index.ts
@@ -1,3 +1,4 @@
+import {FrontChatCmdType} from '../../types/front-chat-types';
 import {boot} from '../boot';
 
 /*
@@ -7,5 +8,5 @@ import {boot} from '../boot';
 export async function initialize(chatId: string, element?: HTMLElement) {
   const frontChat = await boot(element);
 
-  frontChat('init', {chatId});
+  frontChat(FrontChatCmdType.Init, {chatId});
 }

--- a/lib/hooks/use-front-chat-boot/index.ts
+++ b/lib/hooks/use-front-chat-boot/index.ts
@@ -1,7 +1,7 @@
 import {useEffect, useRef, useState} from 'react';
 
 import {boot} from '../../helpers/boot';
-import {type FrontChat, type FrontChatOptions, type FrontChatParams} from '../../types/front-chat-types';
+import {FrontChatCmdType, type FrontChat, type FrontChatOptions, type FrontChatParams} from '../../types/front-chat-types';
 
 /*
  * Types.
@@ -53,7 +53,7 @@ export function useFrontChatBoot(element?: HTMLElement, options?: FrontChatOptio
       return;
     }
 
-    if (cmdType === 'init') {
+    if (cmdType === FrontChatCmdType.Init) {
       const onInitCompleted = () => {
         setStatus(FrontChatStatusesEnum.INITIALIZED);
       };
@@ -61,7 +61,7 @@ export function useFrontChatBoot(element?: HTMLElement, options?: FrontChatOptio
       return window.FrontChat(cmdType, {...params, onInitCompleted});
     }
 
-    if (cmdType === 'shutdown') {
+    if (cmdType === FrontChatCmdType.Shutdown) {
       setStatus(FrontChatStatusesEnum.READY);
     }
 
@@ -73,7 +73,7 @@ export function useFrontChatBoot(element?: HTMLElement, options?: FrontChatOptio
       return;
     }
 
-    frontChat('init', params);
+    frontChat(FrontChatCmdType.Init, params);
   };
 
   return {

--- a/lib/hooks/use-front-chat-boot/index.ts
+++ b/lib/hooks/use-front-chat-boot/index.ts
@@ -1,7 +1,12 @@
 import {useEffect, useRef, useState} from 'react';
 
 import {boot} from '../../helpers/boot';
-import {FrontChatCmdType, type FrontChat, type FrontChatOptions, type FrontChatParams} from '../../types/front-chat-types';
+import {
+  type FrontChat,
+  FrontChatCmdType,
+  type FrontChatOptions,
+  type FrontChatParams
+} from '../../types/front-chat-types';
 
 /*
  * Types.

--- a/lib/types/front-chat-types/index.ts
+++ b/lib/types/front-chat-types/index.ts
@@ -12,9 +12,10 @@ declare global {
  * Types.
  */
 
-export enum FrontChatCmdType {
+export enum FrontChatCommand {
   Init = 'init',
   Show = 'show',
+  Hide = 'hide',
   Shutdown = 'shutdown'
 }
 

--- a/lib/types/front-chat-types/index.ts
+++ b/lib/types/front-chat-types/index.ts
@@ -30,6 +30,8 @@ export type FrontChatParams = {
   isMobileWebview?: boolean;
   useDefaultLauncher?: boolean;
   onInitCompleted?: () => void;
+  // Allow any other key with a value of string, boolean, object, or undefined
+  [key: string]: string | boolean | object | undefined;
 };
 
 export interface FrontChatOptions {

--- a/lib/types/front-chat-types/index.ts
+++ b/lib/types/front-chat-types/index.ts
@@ -12,11 +12,27 @@ declare global {
  * Types.
  */
 
+export enum FrontChatCmdType {
+  Init = "init",
+  Shutdown = "shutdown",
+}
+
+export type FrontChatParams = {
+  shouldShowWindowOnLaunch?: boolean;
+  shouldExpandOnShowWindow?: boolean;
+  shouldHideCloseButton?: boolean;
+  ShouldHideExpandButton?: boolean;
+  welcomeMessageAppearance?: "hidden" | "always";
+  isMobileWebview?: boolean;
+  useDefaultLauncher?: boolean;
+  onInitCompleted?: () => void;
+}
+
+
 export interface FrontChatOptions {
   nonce?: string;
 }
 
 type UnbindHandler = () => void;
 
-export type FrontChatParams = Record<string, string | boolean | object>;
-export type FrontChat = (cmdType: string, params?: FrontChatParams) => UnbindHandler | undefined;
+export type FrontChat = (cmdType: FrontChatCmdType, params?: FrontChatParams) => UnbindHandler | undefined;

--- a/lib/types/front-chat-types/index.ts
+++ b/lib/types/front-chat-types/index.ts
@@ -13,21 +13,24 @@ declare global {
  */
 
 export enum FrontChatCmdType {
-  Init = "init",
-  Shutdown = "shutdown",
+  Init = 'init',
+  Show = 'show',
+  Shutdown = 'shutdown'
 }
 
 export type FrontChatParams = {
+  chatId?: string;
+  userId?: string;
+  userHash?: string;
   shouldShowWindowOnLaunch?: boolean;
   shouldExpandOnShowWindow?: boolean;
   shouldHideCloseButton?: boolean;
-  ShouldHideExpandButton?: boolean;
-  welcomeMessageAppearance?: "hidden" | "always";
+  shouldHideExpandButton?: boolean;
+  welcomeMessageAppearance?: 'hidden' | 'always';
   isMobileWebview?: boolean;
   useDefaultLauncher?: boolean;
   onInitCompleted?: () => void;
-}
-
+};
 
 export interface FrontChatOptions {
   nonce?: string;


### PR DESCRIPTION
have added types for cmd type and adding front chat params from the documentation for easier type navigation based on documentation while keeping the option to pass additional params as needed

<img width="944" alt="image" src="https://github.com/user-attachments/assets/45b90c45-e750-451c-87f4-bfce2b582e32" />
