### PR TITLE
Fix type `FrontChatParams`

### DIFF
--- a/lib/types/front-chat-types/index.ts
+++ b/lib/types/front-chat-types/index.ts
@@ -18,5 +18,5 @@ export interface FrontChatOptions {
 
 type UnbindHandler = () => void;
 
-export type FrontChatParams = Record<string, string | boolean | object>;
+export type FrontChatParams = Record<string, string | boolean | object> | ((handler: any) => void);
 export type FrontChat = (cmdType: string, params?: FrontChatParams) => UnbindHandler | undefined;

--- a/lib/types/front-chat-types/index.ts
+++ b/lib/types/front-chat-types/index.ts
@@ -17,6 +17,7 @@ export interface FrontChatOptions {
 }
 
 type UnbindHandler = () => void;
+type Payload = Record<string, string | boolean | object>;
 
-export type FrontChatParams = Record<string, string | boolean | object> | ((handler: any) => void);
+export type FrontChatParams = Payload | ((handler: Payload) => void);
 export type FrontChat = (cmdType: string, params?: FrontChatParams) => UnbindHandler | undefined;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "front-chat-sdk",
-  "version": "0.0.1-beta",
+  "version": "1.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "front-chat-sdk",
-      "version": "0.0.1-beta",
+      "version": "1.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@vanilla-extract/css": "^1.14.0",


### PR DESCRIPTION
Hi!

The documentation [mentions](https://dev.frontapp.com/docs/chat-sdk-reference#frontchatonwindowvisibilitychanged-handler) that the `frontChat` widget controller accepts event listeners, but the current type of `FrontChatParams` does not allow such a `handler` function.  Thus, Typescript keeps complaining.

I've updated the type to fix this issue.

Also, there was a version mismatch between `package.json` & `package-lock.json` which got auto fixed on running `npm install`.

Thanks!