### PR TITLE
Command Types

### DIFF
--- a/examples/boot/index.ts
+++ b/examples/boot/index.ts
@@ -1,4 +1,5 @@
 import {boot} from '../../lib/helpers/boot';
+import {FrontChatCommandsEnum} from '../../lib/types/front-chat-types';
 
 /*
  * Constants.
@@ -17,9 +18,9 @@ boot(document.body)
     // option to the 'init' command. The below callback is just an example of waiting for the chat widget to
     // be initialized, before performing another action.
     const onInitCompleted = () => {
-      frontChat('show');
+      frontChat(FrontChatCommandsEnum.SHOW);
     };
 
-    frontChat('init', {chatId, onInitCompleted});
+    frontChat(FrontChatCommandsEnum.INIT, {chatId, onInitCompleted});
   })
   .catch(console.error);

--- a/examples/react-embed-front-chat/index.tsx
+++ b/examples/react-embed-front-chat/index.tsx
@@ -1,5 +1,7 @@
 import {useEffect, useRef} from 'react';
 
+import {FrontChatCommandsEnum} from '../../lib/types/front-chat-types';
+
 /*
  * Constants.
  */
@@ -33,7 +35,7 @@ export function App() {
     scriptTag.setAttribute('type', 'text/javascript');
     scriptTag.setAttribute('src', scriptSrc);
     scriptTag.onload = () => {
-      iframe.contentWindow?.FrontChat?.('init', {
+      iframe.contentWindow?.FrontChat?.(FrontChatCommandsEnum.INIT, {
         chatId,
         useDefaultLauncher: false,
         shouldShowWindowOnLaunch: true,

--- a/examples/react-use-front-chat-boot/index.tsx
+++ b/examples/react-use-front-chat-boot/index.tsx
@@ -1,6 +1,7 @@
 import {useEffect, useState} from 'react';
 
 import {useFrontChatBoot} from '../../lib/hooks/use-front-chat-boot';
+import {FrontChatCommandsEnum} from '../../lib/types/front-chat-types';
 
 /*
  * Constants.
@@ -34,7 +35,7 @@ export function App() {
       return;
     }
 
-    frontChat('show');
+    frontChat(FrontChatCommandsEnum.SHOW);
     setIsWindowVisible;
   }, [frontChat, isInitialized, isWindowVisible]);
 

--- a/examples/react-verified-user/index.tsx
+++ b/examples/react-verified-user/index.tsx
@@ -2,6 +2,7 @@ import {createHmac} from 'crypto';
 import {useEffect, useState} from 'react';
 
 import {useFrontChatBoot} from '../../lib/hooks/use-front-chat-boot';
+import {FrontChatCommandsEnum} from '../../lib/types/front-chat-types';
 
 /*
  * Constants.
@@ -52,7 +53,7 @@ export function App() {
       return;
     }
 
-    frontChat('show');
+    frontChat(FrontChatCommandsEnum.SHOW);
     setIsWindowVisible;
   }, [frontChat, isInitialized, isWindowVisible]);
 

--- a/lib/helpers/initialize/index.ts
+++ b/lib/helpers/initialize/index.ts
@@ -1,3 +1,4 @@
+import {FrontChatCommandsEnum} from '../../types/front-chat-types';
 import {boot} from '../boot';
 
 /*
@@ -7,5 +8,5 @@ import {boot} from '../boot';
 export async function initialize(chatId: string, element?: HTMLElement) {
   const frontChat = await boot(element);
 
-  frontChat('init', {chatId});
+  frontChat(FrontChatCommandsEnum.INIT, {chatId});
 }

--- a/lib/hooks/use-front-chat-boot/index.ts
+++ b/lib/hooks/use-front-chat-boot/index.ts
@@ -1,7 +1,12 @@
 import {useEffect, useRef, useState} from 'react';
 
 import {boot} from '../../helpers/boot';
-import {type FrontChat, type FrontChatOptions, type FrontChatParams} from '../../types/front-chat-types';
+import {
+  type FrontChat,
+  FrontChatCommandsEnum,
+  type FrontChatOptions,
+  type FrontChatParams
+} from '../../types/front-chat-types';
 
 /*
  * Types.
@@ -53,7 +58,7 @@ export function useFrontChatBoot(element?: HTMLElement, options?: FrontChatOptio
       return;
     }
 
-    if (cmdType === 'init') {
+    if (cmdType === FrontChatCommandsEnum.INIT) {
       const onInitCompleted = () => {
         setStatus(FrontChatStatusesEnum.INITIALIZED);
       };
@@ -61,7 +66,7 @@ export function useFrontChatBoot(element?: HTMLElement, options?: FrontChatOptio
       return window.FrontChat(cmdType, {...params, onInitCompleted});
     }
 
-    if (cmdType === 'shutdown') {
+    if (cmdType === FrontChatCommandsEnum.SHUTDOWN) {
       setStatus(FrontChatStatusesEnum.READY);
     }
 
@@ -73,7 +78,7 @@ export function useFrontChatBoot(element?: HTMLElement, options?: FrontChatOptio
       return;
     }
 
-    frontChat('init', params);
+    frontChat(FrontChatCommandsEnum.INIT, params);
   };
 
   return {

--- a/lib/types/front-chat-types/index.ts
+++ b/lib/types/front-chat-types/index.ts
@@ -1,4 +1,15 @@
 /*
+ * Enums.
+ */
+
+export enum FrontChatCommandsEnum {
+  INIT = 'init',
+  SHOW = 'show',
+  HIDE = 'hide',
+  SHUTDOWN = 'shutdown'
+}
+
+/*
  * Global types.
  */
 
@@ -12,11 +23,30 @@ declare global {
  * Types.
  */
 
+export type FrontChatParams = {
+  /* Required params. */
+  chatId?: string;
+  /* Identity params. */
+  userId?: string;
+  userHash?: string;
+  /* Widget configuration params. */
+  useDefaultLauncher?: boolean;
+  shouldShowWindowOnLaunch?: boolean;
+  shouldExpandOnShowWindow?: boolean;
+  shouldHideCloseButton?: boolean;
+  shouldHideExpandButton?: boolean;
+  welcomeMessageAppearance?: 'hidden' | 'always';
+  isMobileWebview?: boolean;
+  /* Callbacks. */
+  onInitCompleted?: () => void;
+  /* Unspecified params. */
+  [key: string]: unknown;
+};
+
 export interface FrontChatOptions {
   nonce?: string;
 }
 
 type UnbindHandler = () => void;
 
-export type FrontChatParams = Record<string, string | boolean | object>;
 export type FrontChat = (cmdType: string, params?: FrontChatParams) => UnbindHandler | undefined;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "front-chat-sdk",
-  "version": "0.0.1-beta",
+  "version": "1.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "front-chat-sdk",
-      "version": "0.0.1-beta",
+      "version": "1.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@vanilla-extract/css": "^1.14.0",


### PR DESCRIPTION
Implements types to match our documentation for initializing and configuring Front Chat: https://dev.frontapp.com/docs/chat-sdk-reference

Addresses:
- https://github.com/frontapp/front-chat-sdk/pull/25
- https://github.com/frontapp/front-chat-sdk/pull/26

The approach follows what is seen in these other PRs, but with some tweaks for the code to follow our internal style guidelines.