### PR TITLE
SEC-704: Pin all nonlocal actions

### DIFF
--- a/.github/workflows/build-and-publish-npm.yml
+++ b/.github/workflows/build-and-publish-npm.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Cache and Install npm
         uses: ./.github/actions/cache-and-install-npm
       - name: Build Package

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/cache-and-install-npm
       - name: Package JSON
         run: npm run sort-package-json:check
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/cache-and-install-npm
       - name: Prettier
         run: npm run prettier:check
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/cache-and-install-npm
       - name: Lint
         run: npm run lint
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/cache-and-install-npm
       - name: Unused Exports
         run: npm run unused-exports


### PR DESCRIPTION
https://front.atlassian.net/browse/SEC-704
Now that we have allowlisted all existing GH actions, we should work to pin all to a full length SHA commit as a security measure in response to the tj-actions incident.

Safe to revert.

This major upgrade has been done before without issue, expect low risk.